### PR TITLE
Update for new Facebook tags

### DIFF
--- a/src/validateFacebookTags.js
+++ b/src/validateFacebookTags.js
@@ -1,5 +1,7 @@
 // https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags
-const validFacebookTags = [
+
+// TODO: Remove these from January 15th 2020
+const deprecatedFacebookTags = [
     'BUSINESS_PRODUCTIVITY',
     'COMMUNITY_ALERT',
     'CONFIRMED_EVENT_REMINDER',
@@ -19,6 +21,15 @@ const validFacebookTags = [
     'TICKET_UPDATE',
 ];
 
-const validateFacebookTags = tag => validFacebookTags.includes(tag);
+const validFacebookTags = [
+    'CONFIRMED_EVENT_UPDATE',
+    'POST_PURCHASE_UPDATE',
+    'ACCOUNT_UPDATE',
+    'HUMAN_AGENT',
+];
+
+const allValidTags = [...deprecatedFacebookTags, ...validFacebookTags];
+
+const validateFacebookTags = tag => allValidTags.includes(tag);
 
 export default validateFacebookTags;

--- a/test/unit/validateFacebookTags.test.js
+++ b/test/unit/validateFacebookTags.test.js
@@ -34,6 +34,7 @@ describe('Validate Facebook tags', () => {
         'TRANSPORTATION_UPDATE',
         'FEATURE_FUNCTIONALITY_UPDATE',
         'TICKET_UPDATE',
+
         // New valid tags
         'CONFIRMED_EVENT_UPDATE',
         'POST_PURCHASE_UPDATE',

--- a/test/unit/validateFacebookTags.test.js
+++ b/test/unit/validateFacebookTags.test.js
@@ -16,6 +16,7 @@ describe('Validate Facebook tags', () => {
     });
 
     [
+        // Deprecated tags
         'BUSINESS_PRODUCTIVITY',
         'COMMUNITY_ALERT',
         'CONFIRMED_EVENT_REMINDER',
@@ -33,6 +34,11 @@ describe('Validate Facebook tags', () => {
         'TRANSPORTATION_UPDATE',
         'FEATURE_FUNCTIONALITY_UPDATE',
         'TICKET_UPDATE',
+        // New valid tags
+        'CONFIRMED_EVENT_UPDATE',
+        'POST_PURCHASE_UPDATE',
+        'ACCOUNT_UPDATE',
+        'HUMAN_AGENT',
     ].forEach((tag) => {
         it(`should be true if valid tag '${tag}' given`, () => {
             expect(validateFacebookTags(tag)).to.be.true;


### PR DESCRIPTION
* Update to include new Facebook tags as per the update [here](https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags/)
* Will need to deprecate the old tags on 15th January 2020